### PR TITLE
Disabled submit buttons when captcha is not filled out

### DIFF
--- a/frontend/src/components/pages/ContactUs.tsx
+++ b/frontend/src/components/pages/ContactUs.tsx
@@ -98,7 +98,11 @@ const ContactUs = (): JSX.Element => {
                             captcha={captchaRef}
                             setCaptchaToken={setCaptchaToken}
                         />
-                        <Button type="submit" sx={{ my: 2 }}>
+                        <Button
+                            type="submit"
+                            sx={{ my: 2 }}
+                            disabled={!captchaToken}
+                        >
                             Submit
                         </Button>
                     </FormControl>

--- a/frontend/src/components/pages/authentication/Forget.tsx
+++ b/frontend/src/components/pages/authentication/Forget.tsx
@@ -103,6 +103,7 @@ const Forget = (): JSX.Element => {
                             setCaptchaToken={setCaptchaToken}
                         />
                         <Button
+                            disabled={!captchaToken}
                             onClick={() => setSubmit("reset")}
                             type="submit"
                             sx={{ my: 2 }}
@@ -110,6 +111,7 @@ const Forget = (): JSX.Element => {
                             Reset Password
                         </Button>
                         <Button
+                            disabled={!captchaToken}
                             onClick={() => setSubmit("verify")}
                             type="submit"
                             sx={{ my: 2 }}


### PR DESCRIPTION
# Description

Disabled submit buttons when captcha is not filled out

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Cypress e2e tests
- [x] Cypress (frontend) unit tests
- [x] Jest (backend) unit tests

**Test Configuration**:
* Firmware version: Node.js, version 20 <=
* Hardware: GitHub Actions / ubuntu-latest
* Toolchain: Jest 29.7 <=, Cypress 13.10 <=
* SDK: JavaScript, TypeScript

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
