### PR TITLE
Retrieve private chat hotfix

### DIFF
--- a/dev-local.sh
+++ b/dev-local.sh
@@ -1,2 +1,3 @@
 docker compose -f docker-compose.dev.local.yml up -d
 (cd backend && npx supabase start)
+(cd backend && npx supabase db reset)

--- a/frontend/src/components/pages/chat/Chats.tsx
+++ b/frontend/src/components/pages/chat/Chats.tsx
@@ -1184,7 +1184,7 @@ const Chatroom = ({
     const [searchStr, setSearchStr] = useState("");
     const { user } = useAuth();
     const { mutate } = useEditChat();
-    const { setNewKey, deleteKey } = useEncryptionKey(chat);
+    const { setNewKey, deleteKey, privateKey } = useEncryptionKey(chat);
 
     const deleteMember = (userID: string): void => {
         try {
@@ -1389,6 +1389,12 @@ const Chatroom = ({
                     )}
                 </Paper>
             </Box>
+            {chat.encrypted && !privateKey && (
+                <Typography textAlign="center" color="error" m={2}>
+                    * Messages for encrypted chats cannot be sent or retrieved
+                    until you have set a private key.
+                </Typography>
+            )}
         </Box>
     );
 };

--- a/frontend/src/hooks/useMessages.ts
+++ b/frontend/src/hooks/useMessages.ts
@@ -127,7 +127,10 @@ export const useMessages = (
             }
             return null;
         },
-        enabled: !!token,
+        enabled:
+            !!token &&
+            ((chat.encrypted && !!publicKey && !!privateKey) ||
+                !chat.encrypted),
         staleTime: 1,
     });
 


### PR DESCRIPTION
# Description

Disabled chat message retrieval if encrypted chat's private keys are not set.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Cypress e2e tests
- [x] Cypress (frontend) unit tests
- [x] Jest (backend) unit tests

**Test Configuration**:
* Firmware version: Node.js, version 20 <=
* Hardware: GitHub Actions / ubuntu-latest
* Toolchain: Jest 29.7 <=, Cypress 13.10 <=
* SDK: JavaScript, TypeScript

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
